### PR TITLE
I modified testtools/td/scripts/Test so that it works in the director…

### DIFF
--- a/software/builder/templates/auditshell.c
+++ b/software/builder/templates/auditshell.c
@@ -1,5 +1,6 @@
 struct program_description_t {
-    char const *auditFile, *auditEntry, *compilationLogin, *compilationDate;
+    char const *auditFile, *auditEntry, *compilationLogin, *compilationDate, *platform, *release;
 } ProgramDescription = {
-    AuditFile_, AuditEntry_, CompilationLogin_, CompilationDate_
+  AuditFile_, AuditEntry_, CompilationLogin_, CompilationDate_, Platform_, Release_
 };
+

--- a/software/src/8.0/src/M_SunOS/make.CC
+++ b/software/src/8.0/src/M_SunOS/make.CC
@@ -16,10 +16,10 @@ CDEFS	= -D_POSIX_C_SOURCE=199506L -D__EXTENSIONS__ -DVisionBuild
 CINCS	=
 CBASE	= -mt -KPIC -template=no%extdef
 CDBG	= -g -xs
-CREL	= -g0 -O5 -xvector
+CREL	= -O -xvector
 CVER	= ${CREL}
 C32	= -xarch=v8plus sun.v8plus.il
-C64	= -xarch=v9 -xmemalign=8i sun.v9.il
+C64	= -m64 -xmemalign=8i sun.v9.il
 CARCH	= ${C64}
 CFLAGS	= ${CVER} ${CBASE} ${CARCH}
 
@@ -34,7 +34,7 @@ release64 : targets
 
 release32 : targets-32
 
-debug : targets-dbg targets-dbg32
+debug : targets-dbg
 
 debug64 : targets-dbg
 

--- a/software/src/8.0/src/M_SunOS/make.CC.lib
+++ b/software/src/8.0/src/M_SunOS/make.CC.lib
@@ -15,10 +15,10 @@ CDEFS	= -D_POSIX_C_SOURCE=199506L -D__EXTENSIONS__
 CINCS	=
 CBASE	= -mt -KPIC -template=no%extdef
 CDBG	= -g -xs
-CREL	= -g0 -O5 -xvector
+CREL	= -O -xvector
 CVER	= ${CREL}
 C32	= -xarch=v8plus sun.v8plus.il
-C64	= -xarch=v9 -xmemalign=8i sun.v9.il
+C64	= -m64 -xmemalign=8i sun.v9.il
 CARCH	= ${C64}
 CFLAGS	= ${CVER} ${CBASE} ${CARCH}
 
@@ -33,7 +33,7 @@ release64 : targets
 
 release32 : targets-32
 
-debug : targets-dbg targets-dbg32
+debug : targets-dbg 
 
 debug64 : targets-dbg
 

--- a/software/testtools/td/scripts/Test
+++ b/software/testtools/td/scripts/Test
@@ -3,21 +3,21 @@
 unalias cd
 unalias ls
 
-set HostName	= `uname -n`
-set HostId	= `uname -n -m`
-set OSVersion	= `uname -s -r -v`
-set TestDate	= `date`
+set HostName    = `uname -n`
+set HostId      = `uname -n -m`
+set OSVersion   = `uname -s -r -v`
+set TestDate    = `date`
 
 if ($#argv > 3) then
     set TDComponentsUpperDir = $argv[4]
 else
-    set TDComponentsUpperDir = ~software/engine/testtools/td/component
+    set TDComponentsUpperDir = ~/vision-master/software/testtools/td/component
 endif
 
 if ($#argv > 2) then
     set TDVersion = $argv[3]
 else
-    set TDVersion = 8.0 
+    set TDVersion = 8.0
 endif
 
 set TDComponents = $TDComponentsUpperDir/$TDVersion
@@ -29,80 +29,61 @@ endif
 if ($#argv > 1) then
     setenv NDFPathName $argv[2]
 endif
-    
-if (-d engine) then
-    set enginepath = $cwd/engine
-else if (-d ../engine) then
-    set enginepath = `(cd ../engine; pwd)`
-else if (-d ../../engine) then
-    set enginepath = `(cd ../../engine; pwd)`
-else if (-d ../../../engine) then
-    set enginepath = `(cd ../../../engine; pwd)`
-else if (-d ../../../../engine) then
-    set enginepath = `(cd ../../../../engine; pwd)`
-else if (-d ../../../../../engine) then
-    set enginepath = `(cd ../../../../../engine; pwd)`
-else if (-d ../../../../../../engine) then
-    set enginepath = `(cd ../../../../../../engine; pwd)`
-else if (-d ../../../../../../../engine) then
-    set enginepath = `(cd ../../../../../../../engine; pwd)`
-else if (-d ../../../../../../../../engine) then
-    set enginepath = `(cd ../../../../../../../../engine; pwd)`
+
+if (-d software) then
+    set softwarepath = $cwd/software
+else if (-d ../software) then
+    set softwarepath = `(cd ../software; pwd)`
+else if (-d ../../software) then
+    set softwarepath = `(cd ../../software; pwd)`
+else if (-d ../../../software) then
+    set softwarepath = `(cd ../../../software; pwd)`
+else if (-d ../../../../software) then
+    set softwarepath = `(cd ../../../../software; pwd)`
+else if (-d ../../../../../software) then
+    set softwarepath = `(cd ../../../../../software; pwd)`
+else if (-d ../../../../../../software) then
+    set softwarepath = `(cd ../../../../../../software; pwd)`
+else if (-d ../../../../../../../software) then
+    set softwarepath = `(cd ../../../../../../../software; pwd)`
+else if (-d ../../../../../../../../software) then
+    set softwarepath = `(cd ../../../../../../../../software; pwd)`
 else
-    set enginepath = `pwd`
+    set softwarepath = `pwd`
 endif
 
 # Always check, whenever there are ambiguity, list all candidates and exit...
-# The release string provided by users should be either "project/projectName","release/releaseNumber", or "projectName", "releaseNumber".
-# For example, "project/linux-port","release/7.0.1", "release-7.0.1extensions", "7.0.2".
+# The release string provided by users should be either "src/projectName","release/releaseNumber", or "projectName", "releaseNumber".
+# For example, "src/linux-port","release/7.0.1", "release-7.0.1extensions", "7.0.2".
 if ($#argv > 0) then
-    if (-d $enginepath/$argv[1]) then
+    if (-d $softwarepath/$argv[1]) then
         set Release = $argv[1]
-    else if (-d $enginepath/project/$argv[1]) then
-        set Release = project/$argv[1]
-    else if (-d $enginepath/release/$argv[1]) then
-        set Release = release/$argv[1]
+    else if (-d $softwarepath/src/$argv[1]) then
+        set Release = src/$argv[1]
     else
-        echo "Cannot find directory $enginepath/$argv[1], $enginepath/project/$argv[1] or $enginepath/release/$argv[1]"
+        echo "Cannot find directory $softwarepath/$argv[1] or $softwarepath/src/$argv[1]"
         exit 1
     endif
 else
     set candidates = ()
-    set releases = (`cd $enginepath/project; ls`)
+    set releases = (`cd $softwarepath/src; ls`)
     foreach release ($releases)
-        if (-x $enginepath/project/$release/src/backend/batchvision) then
-	    set candidates = ($candidates project/$release)
-	endif
+        if (-x $softwarepath/src/$release/src/backend/batchvision) then
+            set candidates = ($candidates src/$release)
+        endif
     end
-    set releases = (`cd $enginepath/release; ls`)
-    foreach release ($releases)
-        if (-x $enginepath/release/$release/src/backend/batchvision) then
-	    set candidates = ($candidates release/$release)
-	else
-	    set minorReleases = (`cd $enginepath/release/$release; ls -d */*`)
-	    foreach minorRelease ($minorReleases)
-		if (-x $enginepath/release/$release/$minorRelease/src/backend/batchvision) then
-		    set candidates = ($candidates release/$release/$minorRelease)
-		endif
-	    end
-	endif
-    end
-#    if ($#candidates == 1) then
-#	set Release = $candidates[1]
-#    else
-	echo "Usage On '$HostName':"
-	foreach candidate ($candidates)
-	    echo "   $0 $candidate [ndf [TDversion [componentDirectory]]]"
-	end
-	exit 1
-#    endif
+        echo "Usage On '$HostName':"
+        foreach candidate ($candidates)
+            echo "   $0 $candidate [ndf [TDversion [componentDirectory]]]"
+        end
+        exit 1
 endif
 
 set Tag = "$HostName $Release $TestDate"
 
-set ReleaseDirectory	= "$enginepath/$Release"
-set ReleaseExecutable	= "$ReleaseDirectory/src/backend/batchvision"
-set ReleaseOutput	= "$ReleaseDirectory/src/backend/TD/component.$TDVersion"
+set ReleaseDirectory    = "$softwarepath/$Release"
+set ReleaseExecutable   = "$ReleaseDirectory/src/backend/batchvision"
+set ReleaseOutput       = "$ReleaseDirectory/src/backend/TD/component.$TDVersion"
 
 if (! -x $ReleaseExecutable) then
     echo ">>> Vision Release $Release Does Not Exist On '$HostName'"
@@ -126,21 +107,21 @@ cd $ReleaseOutput/..
 #######################################################################################################################
 
 cat /dev/null > LOG.$TDVersion
-echo	 "********************************************************">>LOG.$TDVersion
-echo	 "*  Test Suite Execution"			>> LOG.$TDVersion
-echo	 "*    Test Date . . . . . . . $TestDate"	>> LOG.$TDVersion
-echo	 "*    Machine . . . . . . . . $HostId"		>> LOG.$TDVersion
-echo	 "*    OS Version. . . . . . . $OSVersion"	>> LOG.$TDVersion
-echo	 "*    Release Name. . . . . . $Release"	>> LOG.$TDVersion
-echo	 "*    Test Suite Version. . . $TDVersion"	>> LOG.$TDVersion
+echo     "********************************************************">>LOG.$TDVersion
+echo     "*  Test Suite Execution"                      >> LOG.$TDVersion
+echo     "*    Test Date . . . . . . . $TestDate"       >> LOG.$TDVersion
+echo     "*    Machine . . . . . . . . $HostId"         >> LOG.$TDVersion
+echo     "*    OS Version. . . . . . . $OSVersion"      >> LOG.$TDVersion
+echo     "*    Release Name. . . . . . $Release"        >> LOG.$TDVersion
+echo     "*    Test Suite Version. . . $TDVersion"      >> LOG.$TDVersion
 echo     "*    Components Directory. . $TDComponentsUpperDir" >> LOG.$TDVersion
 if ($?NDFPathName) then
-   echo "*    NDF . . . . . . . . . . $NDFPathName"	>> LOG.$TDVersion
+   echo "*    NDF . . . . . . . . . . $NDFPathName"     >> LOG.$TDVersion
 endif
-echo	 "*    Release Audit:"				>> LOG.$TDVersion
+echo     "*    Release Audit:"                          >> LOG.$TDVersion
 strings $ReleaseExecutable | grep AUDIT | sed 's/AUDITINFO:/*        /g' >> LOG.$TDVersion
-echo	 "*    Execution Tag . . . . . $Tag"		>> LOG.$TDVersion
-echo	 "********************************************************">>LOG.$TDVersion
+echo     "*    Execution Tag . . . . . $Tag"            >> LOG.$TDVersion
+echo     "********************************************************">>LOG.$TDVersion
 
 cat LOG.$TDVersion
 
@@ -163,9 +144,4 @@ QUIT
 @@@EOD@@@
 
 echo "" >> $ReleaseOutput/../LOG.$TDVersion
-
-
-
-
-
 


### PR DESCRIPTION
…y tree as released. batchvision passes all pieces of the testdeck, except the final component  truncate.S.

auditshell.c was an older version. I updated that so that release information could be embedded in the executables.

Removed the g0 from CC command line. With it, the batchvision executable was 300MB (vs our 7.1.7 release of 18MB)

Dropped the optimization level from 5 to 3 (the default) so that 123.45 printWithCommas: -10.5 would work without a Read-Eval-Print error.

Removed the 32bit version from the default targets for the debug mode build (it didnt work, and we dont use 32bit anymore, anyway)
