### PR TITLE
Assume Linux 'make' IS GNU make by default.

### DIFF
--- a/software/builder/visionBuilder
+++ b/software/builder/visionBuilder
@@ -142,21 +142,23 @@ function getMakeOpts() {
   CPUCOUNT=1
   case $OS in
   Linux)
+    [[ "$GMAKEBIN" == "" ]] && GMAKEBIN=make
     CPUCOUNT=`grep -c processor /proc/cpuinfo`
-    [[ "$MAKEBIN" == "" ]] && MAKEBIN=gmake
+    [[ "$MAKEBIN" == "" ]] && MAKEBIN=$GMAKEBIN
     ;;
   SunOS)
+    [[ "$GMAKEBIN" == "" ]] && GMAKEBIN=gmake
     # For now we don't use CPUCOUNT, but we will if we ever use gmake.
     CPUCOUNT=`psrinfo | wc -l`
-    [[ "$MAKEBIN" == "" ]] && MAKEBIN=gmake
+    [[ "$MAKEBIN" == "" ]] && MAKEBIN=$GMAKEBIN
     ;;
   Default)
     error "Unsupported OS: `$OS`"
     ;;
   esac
-  
+
   # Use parallel make if possible.
-  [[ "$MAKEBIN" == "gmake" ]] && MAKEOPTS="-j`expr $CPUCOUNT + 1`"
+  [[ "$MAKEBIN" == "$GMAKEBIN" ]] && MAKEOPTS="-j`expr $CPUCOUNT + 1`"
 
   # handle KEEPGOING option.
   if [[ $KEEPGOING ]]; then


### PR DESCRIPTION
As written, visionBuilder assumed that the default version of 'make' on LINUX was
something other than GNU make.  While this assumption likely remains valid for
vendor specific Unix versions (e.g., SunOS) and FreeBSD, Linux distros (distros
whose 'uname' returns 'Linux') all appear to use GNU make.

Note that this change addresses issues that are more than cosmetic.  Unless the
MAKEBIN environment variable is defined to be 'make' prior to running 'visionBuilder',
all builds fail almost immediately with an error complaining that the 'gmake' command
was not found.  While defining MAKEBIN averts that error, it confuses 'visionBuilder'
into thinking that it is not using GNU make when, in fact, it is.  Thus confused,
'visionBuilder' does not make use of GNU make specific functionality (specifically,
the -j option) -- a very valuable option when building on a high core count machine :-)