### PR TITLE
Define 'struct sigvec' properly for the Vision editor.

### DIFF
--- a/software/src/8.0/src/frontend/Vk.h
+++ b/software/src/8.0/src/frontend/Vk.h
@@ -698,7 +698,7 @@ typedef void (*STD_SignalHandlerType) (
     struct sigcontext		*scp
 );
 
-#if defined(solaris_2)
+#if defined(solaris_2) || defined(__linux__) && !defined(__USE_BSD)
 struct sigvec {
     STD_SignalHandlerType	sv_handler;
     int				sv_mask;


### PR DESCRIPTION
The Vision editor (aka, the frontend) has its own version of Vk.h that's different
from the one found in the 'kernel' directory.  Duplicate the changes of commit
https://github.com/vision-dbms/vision/commit/424780edb6b0393e8f8be252807a95b967fe3279 in that file.