### PR TITLE
Workaround for a significant g++ compiler bug + other usability changes.

### DIFF
--- a/software/builder/VLINK-CC
+++ b/software/builder/VLINK-CC
@@ -47,7 +47,7 @@ case Linux:
 # for more information), use that compiler here too...
     if ( $?CXX ) then
 	set Compiler = $CXX
-    else if
+    else 
 	set Compiler = g++
     endif
     breaksw

--- a/software/builder/VLINK-CC
+++ b/software/builder/VLINK-CC
@@ -42,7 +42,14 @@ case AIX:
     set Compiler = xlC
     breaksw
 case Linux:
-    set Compiler = g++
+####
+# If 'visionBuilder' is overriding the compiler (see comments in 'visionBuilder'
+# for more information), use that compiler here too...
+    if ( $?CXX ) then
+	set Compiler = $CXX
+    else if
+	set Compiler = g++
+    endif
     breaksw
 case SunOS:
     set Compiler = CC

--- a/software/builder/audit
+++ b/software/builder/audit
@@ -26,7 +26,9 @@ echo "----------------------------------------------------------------" >> $Audi
 echo "+++Entry:   " $AuditEntry >> $AuditFile
 echo "+++Login:   " $LOGNAME >> $AuditFile
 echo "+++Command: " $argv[*] >> $AuditFile
-CC -V >>& $AuditFile
+####
+# Commented out... needs a different command on Linux...
+# CC -V >>& $AuditFile
 echo "+++Platform: `uname -a`" >> $AuditFile
 
 ####  ... write the audit comment, ...

--- a/software/builder/visionBuilder
+++ b/software/builder/visionBuilder
@@ -134,22 +134,24 @@ function doLinkSrc() {
 
 # Get make options.
 function getMakeOpts() {
-  [[ "$CPUCOUNT" != "" ]] && return;
-  
+  # Set our expectations regarding 'make' on this platform...
   local OS=`uname`
-
-  # Find our CPU count, default to 1.
-  CPUCOUNT=1
   case $OS in
   Linux)
     [[ "$GMAKEBIN" == "" ]] && GMAKEBIN=make
-    CPUCOUNT=`grep -c processor /proc/cpuinfo`
     [[ "$MAKEBIN" == "" ]] && MAKEBIN=$GMAKEBIN
+
+    # Now that 'vision' is open source, we need a way to compile
+    # it with alternative versions of 'g++' (e.g., when bugs are
+    # discovered or suspected in the default compiler:-)  GNU make
+    # provides an easy way to do that by simply overriding the
+    # value of the CXX variable on the 'make' command line. Do
+    # that here if the 'CXX' environment variable is defined:
+    [[ -v CXX ]] && MAKEOPTS="CXX=$CXX"
+
     ;;
   SunOS)
     [[ "$GMAKEBIN" == "" ]] && GMAKEBIN=gmake
-    # For now we don't use CPUCOUNT, but we will if we ever use gmake.
-    CPUCOUNT=`psrinfo | wc -l`
     [[ "$MAKEBIN" == "" ]] && MAKEBIN=$GMAKEBIN
     ;;
   Default)
@@ -158,12 +160,24 @@ function getMakeOpts() {
   esac
 
   # Use parallel make if possible.
-  [[ "$MAKEBIN" == "$GMAKEBIN" ]] && MAKEOPTS="-j`expr $CPUCOUNT + 1`"
+  if [[ "$MAKEBIN" == "$GMAKEBIN" ]]; then
+      MAKEOPTS="$MAKEOPTS -j"
+      if [[ "$CPUCOUNT" =~ [0-9]+ ]]; then
+	  MAKEOPTS="$MAKEOPTS$CPUCOUNT"
+      fi
+  fi
 
   # handle KEEPGOING option.
-  if [[ $KEEPGOING ]]; then
-    MAKEOPTS="$MAKEOPTS -k"
-  fi
+  # if [[ $KEEPGOING ]]; then
+  #   MAKEOPTS="$MAKEOPTS -k"
+  # fi
+
+  # KEEPGOING (i.e., the '-k' option to make) has been the default for
+  # a long time. Just in case someone ever wants to change that default
+  # in the future, add the required '-k' option to MAKEOPTS here instead
+  # of just adding it to the command line run in 'doSingleBuild':
+
+  MAKEOPTS="$MAKEOPTS -k"
 }
 
 # Build single.
@@ -199,7 +213,7 @@ function doSingleBuild() {
   info "Entering into $BUILDDIR..."
   getMakeOpts
   cd "$SRCDIR/$BUILDDIR" || ( error "Unable to change directory to '$SRCDIR/$BUILDDIR'." && return 1 )
-  nice -n $NICENESS audit $MAKEBIN $MAKEOPTS -k $target
+  nice -n $NICENESS audit $MAKEBIN $MAKEOPTS $target
   if [[ $? != 0 ]]; then
     if $SHOWERRORLOG; then
       info "Build error. Build log for $BUILDDIR:"

--- a/software/builder/visionBuilder
+++ b/software/builder/visionBuilder
@@ -136,21 +136,15 @@ function doLinkSrc() {
 function getMakeOpts() {
   # Set our expectations regarding 'make' on this platform...
   local OS=`uname`
+
   case $OS in
   Linux)
+    [[ ! -v CPUCOUNT ]] && CPUCOUNT=$(grep -c processor /proc/cpuinfo)
     [[ "$GMAKEBIN" == "" ]] && GMAKEBIN=make
     [[ "$MAKEBIN" == "" ]] && MAKEBIN=$GMAKEBIN
-
-    # Now that 'vision' is open source, we need a way to compile
-    # it with alternative versions of 'g++' (e.g., when bugs are
-    # discovered or suspected in the default compiler:-)  GNU make
-    # provides an easy way to do that by simply overriding the
-    # value of the CXX variable on the 'make' command line. Do
-    # that here if the 'CXX' environment variable is defined:
-    [[ -v CXX ]] && MAKEOPTS="CXX=$CXX"
-
     ;;
   SunOS)
+    [[ ! -v CPUCOUNT ]] && CPUCOUNT=$(psrinfo | wc -l)
     [[ "$GMAKEBIN" == "" ]] && GMAKEBIN=gmake
     [[ "$MAKEBIN" == "" ]] && MAKEBIN=$GMAKEBIN
     ;;
@@ -159,12 +153,21 @@ function getMakeOpts() {
     ;;
   esac
 
-  # Use parallel make if possible.
+  # Set GNU make options.
   if [[ "$MAKEBIN" == "$GMAKEBIN" ]]; then
+      # Use parallel make if possible.
       MAKEOPTS="$MAKEOPTS -j"
       if [[ "$CPUCOUNT" =~ [0-9]+ ]]; then
 	  MAKEOPTS="$MAKEOPTS$CPUCOUNT"
       fi
+
+      # Now that 'vision' is open source, we need a way to compile
+      # it with alternative versions of 'g++' (e.g., when bugs are
+      # discovered or suspected in the default compiler:-)  GNU make
+      # provides an easy way to do that by simply overriding the
+      # value of the CXX variable on the 'make' command line. Do
+      # that here if the 'CXX' environment variable is defined:
+      [[ -v CXX ]] && MAKEOPTS="CXX=$CXX"
   fi
 
   # handle KEEPGOING option.

--- a/software/builder/visionBuilder
+++ b/software/builder/visionBuilder
@@ -134,6 +134,8 @@ function doLinkSrc() {
 
 # Get make options.
 function getMakeOpts() {
+  MAKEOPTS=""
+
   # Set our expectations regarding 'make' on this platform...
   local OS=`uname`
 

--- a/software/src/8.0/src/M_Linux/make.gcc
+++ b/software/src/8.0/src/M_Linux/make.gcc
@@ -20,7 +20,7 @@ CDEFS	=  -DVisionBuild
 CINCS	=
 CBASE	= -fexceptions -frtti -Wno-trigraphs
 CDBG	= -g
-CREL	= -O2
+CREL	= -O2 -D_FORTIFY_SOURCE=0
 CVER	= ${CREL}
 
 CFLAGS	= ${CVER} ${CBASE}

--- a/software/src/8.0/src/M_Linux/make.gcc
+++ b/software/src/8.0/src/M_Linux/make.gcc
@@ -2,7 +2,7 @@
 #		Local Compiler Rules			#
 #########################################################
 
-#--objectrule--#	g++ $(CFLAGS) $(CDEFS) $(CINCS) -o $@ -c 
+#--objectrule--#	$(CXX) $(CFLAGS) $(CDEFS) $(CINCS) -o $@ -c 
 #--objectsuffix--#	$B
 #--targetsuffix--#	$B
 #--tarulesuffix--#	$B

--- a/software/src/8.0/src/M_Linux/make.gcc.lib
+++ b/software/src/8.0/src/M_Linux/make.gcc.lib
@@ -2,7 +2,7 @@
 #		Local Compiler Rules			#
 #########################################################
 
-#--objectrule--#	g++ $(CFLAGS) $(CDEFS) $(CINCS) -o $@ -c
+#--objectrule--#	$(CXX) $(CFLAGS) $(CDEFS) $(CINCS) -o $@ -c
 #--objectsuffix--#	$B
 #--targetprefix--#	../lib$D/
 #--buildtargets--#	targets

--- a/software/src/8.0/src/M_Linux/make.gcc.lib
+++ b/software/src/8.0/src/M_Linux/make.gcc.lib
@@ -20,7 +20,7 @@ CDEFS	=
 CINCS	=
 CBASE	= -fexceptions -frtti -Wno-trigraphs -fPIC
 CDBG	= -g
-CREL	= -O2
+CREL	= -O2 -D_FORTIFY_SOURCE=0
 CVER	= ${CREL}
 
 CFLAGS	= ${CVER} ${CBASE}

--- a/software/src/8.0/src/frontend/rsInterface.c
+++ b/software/src/8.0/src/frontend/rsInterface.c
@@ -1393,12 +1393,23 @@ PublicFnDef int main (
     else BackendIsLocal = TRUE;
 
 /***** try to access the BackendPath in execute mode *****/
-
+/*****
+ *
+ *  >>>  ... but only if BackendPath appears to name a specific file, as evidenced
+ *  >>>  by the presence of a '/' character in its value.  Without this test,
+ *  >>>  all $PATH resolved backends (e.g., the frontend's default of 'batchvision'
+ *  >>>  specified by "WhichRS" in this project's 'main.i' file) are rejected by the
+ *  >>>  call to 'access' unless suitably named executable file exists in the current
+ *  >>>  directory.  This change gives 'execvp' the shot it deserves for finding and
+ *  >>>  successfully starting those backends
+ *
+ *****
+ *****/
     RSargs[0] = BackendPath;
-    if (BackendIsLocal && access (BackendPath, 1) != 0)
+    if (BackendIsLocal && strchr (BackendPath, '/') && access (BackendPath, 1) != 0)
     {
-	fprintf (stderr, "ERROR - cannot run the program: %s\n", BackendPath);
-	exit (ErrorExitValue);
+    	fprintf (stderr, "ERROR - cannot run the program: %s\n", BackendPath);
+    	exit (ErrorExitValue);
     }
 
     readCompanyName();

--- a/software/src/8.0/src/frontend/stdcurses.h
+++ b/software/src/8.0/src/frontend/stdcurses.h
@@ -35,8 +35,8 @@
 /* Window structure */
 typedef WINDOW CUR_WINDOW;
 
-#define CUR_maxScrLines	67
-#define CUR_maxScrCols	256
+#define CUR_maxScrLines	256
+#define CUR_maxScrCols	512
 
 /* Curses' Variables */
 #define CUR_stdscr	stdscr


### PR DESCRIPTION
This commit makes two changes to improve the usability of the frontend in the open
environment:

1) It increases the maximum supported screen size.  To deal with limits on stack
   allocated memory (one occurrence in the code), the frontend limited the maximum
   number of rows and columns to values appropriate for the hardware of the day.
   While this change doesn't remove the limits, it increases them to values
   appropriate for modern 4k graphics hardware.
2) It refines an executability pre-test of the desired backend (i.e, 'batchvision')
   to allow the successful execution of $PATH resolved backends.  As originally
   written, this test was always performed; however, the 'access' routine used to
   perform that test is not $PATH aware.  As a result, all $PATH relative backend
   selections were rejected unless a suitably named executable file could be found
   in the current directory.  The change implemented here limits the use of 'access'
   to only those executables that appear to name a specific file (as evidenced by
   the presence of '/').  This seems a reasonable compromise since the original
   reason for the 'access' pre-test is lost in antiquity and code paths that bypass
   that test already exist.