### PR TITLE
Release 8.1 can now bootstrap new databases.

### DIFF
--- a/software/src/8.1/src/backend/RTvstore.cpp
+++ b/software/src/8.1/src/backend/RTvstore.cpp
@@ -1163,7 +1163,7 @@ RTYPE_DefineHandler (rtVSTORE_Handler) {
 	IOBJ_MDE ("setAuxiliaryColumn:"	, SetAuxiliaryColumnDM)
 	IOBJ_MDE ("setColumn:"		, SetColumnDM)
 	IOBJ_MDE ("defineColumn:"	, SetColumnDM)
-//	IOBJ_MDE ("setColumnPtr:"	, SetColumnPtrDM)
+	IOBJ_MDE ("setColumnPtr:"	, SetColumnPtrDM)
 	IOBJ_MDE ("addRows:"		, AddRowsDM)
 	IOBJ_MDE ("clone"		, CloneDM)
     IOBJ_EndMD;


### PR DESCRIPTION
During the development of 8.1, the definition of RTYPE_C_ValueStore's
'setColumnPtr:' bootstrap debugger method was temporarily disabled while
the machinery for its reimplementation was being developed.  While the
machinery was eventually reimplemented, 'setColumnPtr:' remained disabled,
rendering it unable to bootstrap new databases.  This commit corrects that
problem.