### PR TITLE
Fixing pointer alignment issue for Solaris/sparc in the frontend

### DIFF
--- a/software/src/master/src/frontend/buffers.cpp
+++ b/software/src/master/src/frontend/buffers.cpp
@@ -527,7 +527,7 @@ PublicFnDef char *BUF_getLine(LINEBUFFER *buffer, int len) {
     /****        rounded to the nearest word                                    ****/
 
     need = ((((2 * sizeof(char *)) + sizeof(int) + ((len + 1) * sizeof(char)))
-		/ sizeof(int)) + 1) * sizeof(int);
+		/ sizeof(char *)) + 1) * sizeof(char *);
 
     if (need <= BUF_whiteSpace(buffer))     /* take line from end,  */
     { 					    /* adjust white ptr.    */


### PR DESCRIPTION
Entering text in the input buffer would often generate a Bus Error due to pointer arithmetic returning pointers on a multiple of 4 (int) boundary rather than a multiple of 8 (char *). Modifying the code to add a multiple of 8 fixed the problem on Solaris sparc, but if someone would verify that it doesn't cause problems elsewhere ( I wouldn't expect it to) I would be thankful.