### PR TITLE
Fixing an uninitialized variable in the nicePrint primitives

### DIFF
--- a/software/src/master/src/backend/PFprint.cpp
+++ b/software/src/master/src/backend/PFprint.cpp
@@ -936,7 +936,7 @@ void nicePrintRealNumber (VOutputGenerator &rOutputGenerator, int iFieldWidth, i
  *****/
 V_DefinePrimitive (IntegerPrintOf) {
     RTYPE_Type	 rtype;
-    bool	 withCommas, bNice = false, bCompact = false;
+    bool	 withCommas = false, bNice = false, bCompact = false;
     unsigned int converseMessageSelector;
     FMTType	 resultFormat;
 
@@ -944,7 +944,6 @@ V_DefinePrimitive (IntegerPrintOf) {
 /*****  Decode the alias by which this primitive was invoked...  *****/
     switch (V_TOTSC_Primitive) {
     case XIntegerPrintOf:
-        withCommas = false;
 	converseMessageSelector = KS__PrintColon;
         break;
     case XIntegerPrintWithCommasOf:
@@ -1229,11 +1228,10 @@ V_DefinePrimitive (DoublePrintOf) {
 
 
 /*****  Decode the alias by which this primitive was invoked...  *****/
-    bool withCommas, bNice = false, bCompact = false;
+    bool withCommas = false, bNice = false, bCompact = false;
     int converseMessageSelector;
     switch (V_TOTSC_Primitive) {
     case XDoublePrintOf:
-        withCommas = false;
 	converseMessageSelector = KS__PrintColon;
         break;
     case XDoublePrintWithCommasOf:


### PR DESCRIPTION
These -- to my knowledge unused -- primitives had an uninitialized variable which resulted in numbers sometimes being printed with commas when they should not have been.

This fixes that. 