### PR TITLE
Modified components of poolTester so that it works under Solaris10

### DIFF
--- a/software/testtools/poolTester/example.poolTester
+++ b/software/testtools/poolTester/example.poolTester
@@ -1,0 +1,37 @@
+# An example .poolTester init file:
+
+# poolTester will look for this file in your home directory, and then in your current directory,
+#   loading it to initalize whatever settings you desire or need ...
+
+
+# poolTester makes use of the native Linux utility 'seq' in many places
+# Before I found an implementation in an out of the way directory on my
+# Solaris machine, I used this function to provide a sufficient subset of
+# 'seq' functionality to satisfy poolTester's needs.
+
+#function seq () 
+#{ 
+#    i=$1;
+#    if [[ -z $2 ]]; then
+#	l=$1
+#	i=1
+#    else
+#	l=$2
+#    fi
+#    while [ $i -le $l ]; do
+#        printf "%d\n" $i
+#        i=`expr $i + 1`
+#    done
+#}
+
+# need a grep that understands the -q option ....
+alias grep=/usr/xpg4/bin/grep
+
+# the following is needed to make regular expressions work properly on some versions of bash
+shopt -s expand_aliases compat31
+
+# a location for the executables under test 
+export Tools=exe
+
+# NDF for running testDeck01 and its ilk ...
+export NDFPathName=../td/testNetwork-sparc/NDF

--- a/software/testtools/poolTester/include/clean.sh
+++ b/software/testtools/poolTester/include/clean.sh
@@ -65,7 +65,7 @@ function isntFileRetained() {
 #
 function clean() {
     rmOptions="-rf"
-    debug_on && rmOptions="$rmOptions -v"
+#    debug_on && rmOptions="$rmOptions -v"
     local file
     for file in "$scratchSpace/testpool$poolIdx"/*; do
         if isntFileRetained "$file"; then

--- a/software/testtools/poolTester/include/logging.sh
+++ b/software/testtools/poolTester/include/logging.sh
@@ -133,7 +133,8 @@ function compareLog() {
     dumpLog -s > $logFileStripped
     dumpLog -f $expectedLogFile -s > $expectedLogFileStripped
     
-    diff -q $logFileStripped $expectedLogFileStripped >/dev/null
+#    diff -q $logFileStripped $expectedLogFileStripped >/dev/null
+    diff $logFileStripped $expectedLogFileStripped >/dev/null
     case $? in
         0)
             verbose_inform "Pool log matches '$expectedLogFile'."

--- a/software/testtools/poolTester/include/pool.sh
+++ b/software/testtools/poolTester/include/pool.sh
@@ -147,7 +147,7 @@ EOD
 function doesPoolExist () {
 debug_inform "doesPoolExist called"
 	
-	local poolID=1
+	local poolID=$poolIdx
 	# Get current user.
 	local user=`whoami`
 	local poolPID
@@ -174,9 +174,9 @@ debug_inform "doesPoolExist called"
                                 [[ $val -eq 0 ]] && retWarn="pool does not exist"
 				
                 # Perform check.
-                debug_inform "Waiting up to $timeout seconds for pool connection evaluation ($val)."
+                debug_inform "Checking for pool existence ($val)."
 				
-				poolPID=`ps aux|grep vpool| grep $user | grep testpool$poolID| grep -v grep| awk '{print $2}'`
+				poolPID=`ps -af|grep vpool| grep $user | grep testpool$poolID| grep -v grep| awk '{print $2}'`
 				toReturn=$?
 
 				[[ $poolPID -ne 0 ]] && [[ $toReturn -eq 0 ]] && actual=0 || actual=1

--- a/software/testtools/poolTester/include/query.sh
+++ b/software/testtools/poolTester/include/query.sh
@@ -102,8 +102,8 @@ function query() {
     local toRun
     if [[ ! -z "$queryFile" ]]; then
         toRun="$queryFile"
-        verbose_inform "Running query file: $queryFile"
-	verbose_inform "NFD env variable: $NDFPathName"
+        verbose_inform "Running query file: $queryFile expectedResults: $expectedResultsFile"
+	verbose_inform "NDF env variable: $NDFPathName"
 	verbose_inform "Workers startup query: $WorkerStartupQuery"
         getVPrompt $vpromptOptions < $queryFile > $actualResultsFile & 2>&1
 	local vpromptPID=$!
@@ -114,7 +114,7 @@ function query() {
     else
         toRun="$queryExpression"
         [[ ! -z "$queryURL" ]] && toRun="\"$queryURL\" asUrl;"
-        verbose_inform "Running query: $toRun"
+        verbose_inform "Running query: $toRun expectedResults: $expectedResultsFile"
         toRun="$toRun
 ?g"
 	
@@ -122,8 +122,10 @@ function query() {
         echo "$toRun" | getVPrompt $vpromptOptions > $actualResultsFile
     fi
     # Compare results.
+verbose_inform "Compare results: $actualResultsFile $expectedResultsFile"
     [[ -z "$expectedResultsFile" ]] && return 0
-    diff -q $actualResultsFile $expectedResultsFile >/dev/null
+#    diff -q $actualResultsFile $expectedResultsFile >/dev/null
+    diff $actualResultsFile $expectedResultsFile >/dev/null
     case $? in
         0)
             # Test passed. Delete the file and return. 

--- a/software/testtools/poolTester/include/script.sh
+++ b/software/testtools/poolTester/include/script.sh
@@ -21,7 +21,7 @@ function runScript_getValue() {
     
     # TODO: enhance robustness of runScript_getValue()
     local -a kvps # Array of key-value pairs.
-    lines_to_array "`echo $line | sed 's/,/\n/g'`" kvps # Populate array
+    lines_to_array "`echo $line | tr , '\n'`" kvps # Populate array
     for i in `seq 0 $((${#kvps[@]} - 1))`; do # Iterate over array
         # Check if this key-value-pair has the key we're looking for.
         [[ "${kvps[$i]}" =~ "[ 	]*$searchKey[ 	]*:(.*)" ]] || continue
@@ -29,6 +29,7 @@ function runScript_getValue() {
         # We've found the correct key. Output the value and return.
         local value=`trim "${BASH_REMATCH[1]}"`
 	eval "$toReturn='$(echo `eval echo \"$value\"`)'"
+	debug_inform "value found: '$value' -- '$toReturn'"
         break;
     done
 }
@@ -205,7 +206,7 @@ function runScript() {
         runScript_getValue "${threadLines[$i]}" thread threadID
         
         # Start thread.
-        debug_inform "Starting thread $threadID."
+        debug_inform "Starting thread $threadID.($threadLines[$i])"
         runScript_runThread "$scriptFile" "$threadID" &
     done
     

--- a/software/testtools/poolTester/include/startStop.sh
+++ b/software/testtools/poolTester/include/startStop.sh
@@ -333,6 +333,7 @@ EOD
 function restart() {
     require_pool
     local waitForWorkers=false
+    local OPTIND=1
     while getopts 'w' OPTION; do
         case $OPTION in
             w)

--- a/software/testtools/poolTester/include/wait.sh
+++ b/software/testtools/poolTester/include/wait.sh
@@ -11,6 +11,7 @@ function waitForStat() {
     local actual
     local timeout=120
     local conditionMet=false
+    local OPTIND=1
     while getopts 'c:t:' OPTION; do
         case $OPTION in
             c)
@@ -50,6 +51,7 @@ function waitForStat() {
                         conditionMet=true
                         break
                     else
+			debug_inform "$i of $timeout: $actual $cond $val"
                         sleep 1
                     fi
                 done
@@ -78,7 +80,7 @@ Waits until a given pool statistic condition is met, up to a given timeout. For 
 
 At least one of the following arguments must be specified:
     -c CONDITION Specify statistical condition that should be checked for. Should be in the form <VAR><OPERATOR><VALUE> Where <VAR> is the statistic name, <OPERATOR> is the conditional operator (one of: <, <=, >, >=, =, !=) and <VALUE> is the condition's check value.
-    -t TIMEOUT   The timeout of the wait operation in seconds. Only effects subsequent -c arguments. Defaults to 60.
+    -t TIMEOUT   The timeout of the wait operation in seconds. Only effects subsequent -c arguments. Defaults to 120.
 
 Exit status is zero if condition(s) met, nonzero otherwise.
 

--- a/software/testtools/poolTester/queries/longStart.vis
+++ b/software/testtools/poolTester/queries/longStart.vis
@@ -1,4 +1,4 @@
 
-[!x <- 500000; [x > 0] whileTrue:[:x <- x - 1]] value;
-
 Utility define:'processId' toBe: 604 asPrimitive;
+
+"sleep 25" filterOutputOf:[];

--- a/software/testtools/poolTester/scripts/master
+++ b/software/testtools/poolTester/scripts/master
@@ -15,4 +15,4 @@ operation_on_thread:main, poolIdx: $poolIdx/script$operationID, run: runScript -
 operation_on_thread:main, poolIdx: $poolIdx/script$operationID, run: runScript -s $POOLTESTERDIR/scripts/hardStop
 operation_on_thread:main, poolIdx: $poolIdx/script$operationID, run: runScript -s $POOLTESTERDIR/scripts/stop
 operation_on_thread:main, poolIdx: $poolIdx/script$operationID, run: runScript -s $POOLTESTERDIR/scripts/hardRestartNoResume
-operation_on_thread:main, poolIdx: $poolIdx/script$operationID, run: runScript -s $POOLTESTERDIR/scripts/checkProperties
+#operation_on_thread:main, poolIdx: $poolIdx/script$operationID, run: runScript -s $POOLTESTERDIR/scripts/checkProperties

--- a/software/testtools/poolTester/scripts/repeatedHardRestart
+++ b/software/testtools/poolTester/scripts/repeatedHardRestart
@@ -1,0 +1,17 @@
+# Repeated hardRestarts left a pool in a suspended state in early versions of 8.1
+# This script fails with an error when run against that version.
+# It succeeds when run against version 8.0
+# It should succeed when run against a version of 8.1 with the bug fixed!!
+
+#
+pre_exec: start -c $POOLTESTERDIR/configs/max1.ptc
+
+thread:main, repetitions:1
+
+operation_on_thread:main, run:hardRestart
+operation_on_thread:main, run:hardRestart
+operation_on_thread:main, run:query -q $POOLTESTERDIR/queries/TestQuery01.vis -a
+
+post_exec: waitForStat -t 60 -c Status=Running 
+#post_exec: waitForStat -t 60 -c QueriesProcessed=2
+post_exec: hardStop

--- a/software/testtools/poolTester/scripts/testDeck01
+++ b/software/testtools/poolTester/scripts/testDeck01
@@ -3,144 +3,144 @@
 # Dumps statistics after running to show final pool state.
 
 # Pre-Execs
-pre_exec: start
+pre_exec: start -c $POOLTESTERDIR/configs/testDeck.ptc -w
 
 # Query thread 1.
 thread:query1, repetitions:10
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery01.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery01.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery02.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery02.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery03.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery03.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery04.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery04.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery05.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery05.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery06.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery06.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery07.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery07.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery08.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery08.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery09.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery09.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery10.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery10.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery11.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery11.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery12.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery12.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery13.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery13.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery14.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery14.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery15.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery15.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery16.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery16.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery17.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery17.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery18.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery18.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery19.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery19.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery20.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery20.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query1, run:query -q ~/vision-testtools/poolTester/queries/TestQuery21.vis
+operation_on_thread:query1, run:query -q $POOLTESTERDIR/queries/TestQuery21.vis -w
 operation_on_thread:query1, run:checkAssertions || error "Assertions check failed in query thread."
 
 # Query thread 2.
 thread:query2, repetitions:10
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery01.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery01.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery02.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery02.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery03.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery03.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery04.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery04.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery05.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery05.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery06.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery06.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery07.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery07.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery08.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery08.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery09.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery09.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery10.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery10.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery11.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery11.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery12.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery12.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery13.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery13.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery14.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery14.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery15.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery15.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery16.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery16.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery17.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery17.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery18.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery18.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery19.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery19.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery20.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery20.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query2, run:query -q ~/vision-testtools/poolTester/queries/TestQuery21.vis
+operation_on_thread:query2, run:query -q $POOLTESTERDIR/queries/TestQuery21.vis -w
 operation_on_thread:query2, run:checkAssertions || error "Assertions check failed in query thread."
 
 # Query thread 3, runs with anydata.
 thread:query3, repetitions:10
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery01.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery01.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery02.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery02.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery03.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery03.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery04.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery04.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery05.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery05.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery06.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery06.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery07.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery07.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery08.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery08.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery09.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery09.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery10.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery10.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery11.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery11.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery12.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery12.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery13.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery13.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery14.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery14.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery15.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery15.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery16.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery16.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery17.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery17.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery18.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery18.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery19.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery19.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery20.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery20.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
-operation_on_thread:query3, run:query -a -q ~/vision-testtools/poolTester/queries/TestQuery21.vis
+operation_on_thread:query3, run:query -a -q $POOLTESTERDIR/queries/TestQuery21.vis -w
 operation_on_thread:query3, run:checkAssertions || error "Assertions check failed in query thread."
 
 # Restart thread.
@@ -152,4 +152,5 @@ operation_on_thread:restart, run:restart
 post_exec:dumpStats
 post_exec:generationStats
 post_exec:workerStats
+post_exec:quickStats
 post_exec:stop


### PR DESCRIPTION
Added an example .poolTester file which contains some initializations that
  are necessary on some platforms
Added a new test script to replicate the issue where repeated hard restarts
  leave the pool in a suspended state.