### PR TITLE
Don't pass -xmemalign=8i to the Intel Solaris compiler

### DIFF
--- a/software/src/master/src/M_SunOS/make.CC
+++ b/software/src/master/src/M_SunOS/make.CC
@@ -19,7 +19,7 @@ CDBG	= -g -xs
 CREL	= -O -xvector
 CVER	= ${CREL}
 C32	= -m32
-C64	= -m64 -xmemalign=8i
+C64	= -m64
 CARCH	= ${C64}
 CFLAGS	= ${CVER} ${CBASE} ${CARCH}
 

--- a/software/src/master/src/M_SunOS/make.CC.lib
+++ b/software/src/master/src/M_SunOS/make.CC.lib
@@ -20,7 +20,7 @@ CDBG	= -g -xs
 CREL	= -O -xvector
 CVER	= ${CREL}
 C32	= -m32
-C64	= -m64 -xmemalign=8i
+C64	= -m64
 CARCH	= ${C64}
 CFLAGS	= ${CVER} ${CBASE} ${CARCH}
 

--- a/software/src/master/src/M_SunOS/make.processor.gen
+++ b/software/src/master/src/M_SunOS/make.processor.gen
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ $(uname -p) != i386 ]; then
+    echo "C64 += -xmemalign=8i"
+fi

--- a/software/src/master/src/V/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/V/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/Vca/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/Vca/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/VcaMain/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/VcaMain/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/Vdht/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/Vdht/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/Vps/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/Vps/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/Vsa/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/Vsa/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/Vxa/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/Vxa/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/VxaMain/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/VxaMain/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/backend/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/backend/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/dbupdate/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/dbupdate/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/frontend/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/frontend/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/tools/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/tools/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vca_sample_distribution_client/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vca_sample_distribution_client/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vca_sample_distribution_server/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vca_sample_distribution_server/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vca_sample_echostring_client/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vca_sample_echostring_client/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vca_sample_echostring_server/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vca_sample_echostring_server/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vca_samples/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vca_samples/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vcaquery/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vcaquery/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vcaservicemanager/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vcaservicemanager/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vcatool/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vcatool/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vnotify/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vnotify/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vpassthru/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vpassthru/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vpooladmin/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vpooladmin/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vproxy/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vproxy/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vsa_sample_requestmaker/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vsa_sample_requestmaker/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vsaprompt/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vsaprompt/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen

--- a/software/src/master/src/vserver/M_SunOS/make.defs.4.gen
+++ b/software/src/master/src/vserver/M_SunOS/make.defs.4.gen
@@ -1,0 +1,1 @@
+../../M_SunOS/make.processor.gen


### PR DESCRIPTION
Passing -xmemalign=8i to the Intel Solaris compiler generates many warnings.  This pull request modifies our build configuration files to make its use appropriately conditional.  (@c-kuhlman - I took care to ensure that these changes should work in the Sparc build, but since I can't test there, can you confirm that they do?).