### PR TITLE
Address newly absent 'matherr' structures on Linux

### DIFF
--- a/software/src/master/src/backend/PFnumeric.cpp
+++ b/software/src/master/src/backend/PFnumeric.cpp
@@ -164,7 +164,6 @@ extern "C" {
  ******************************************/
 
 #if defined(__linux__) || defined(__APPLE__) || (defined (__HP_aCC) && __cplusplus >= 199707L)
-#define USING_FAKE_MATHERR
 struct exception {
     int type;
     char *name;
@@ -189,10 +188,8 @@ struct exception {
 int __cdecl matherr (
 #if defined(_WIN32)
     struct  _exception *pException
-#elif defined(USING_FAKE_MATHERR)
-    struct   exception *pException
 #else
-    struct __exception *pException
+    struct   exception *pException
 #endif
 ) {
     static const double iNaN (NaNQ);

--- a/software/src/master/src/backend/PFnumeric.cpp
+++ b/software/src/master/src/backend/PFnumeric.cpp
@@ -163,7 +163,8 @@ extern "C" {
  ******************************************
  ******************************************/
 
-#if defined(__APPLE__) || (defined (__HP_aCC) && __cplusplus >= 199707L)
+#if defined(__linux__) || defined(__APPLE__) || (defined (__HP_aCC) && __cplusplus >= 199707L)
+#define USING_FAKE_MATHERR
 struct exception {
     int type;
     char *name;
@@ -188,10 +189,10 @@ struct exception {
 int __cdecl matherr (
 #if defined(_WIN32)
     struct  _exception *pException
-#elif defined(__linux__)
-    struct __exception *pException
-#else
+#elif defined(USING_FAKE_MATHERR)
     struct   exception *pException
+#else
+    struct __exception *pException
 #endif
 ) {
     static const double iNaN (NaNQ);


### PR DESCRIPTION
As of 'glibc' 2.27 (see issue #48), Linux no longer supports 'matherr'.
For our purposes, the implication of that change is the disappearance
of a definition for 'struct __exception' from the <math.h> header files.
For portability reasons, our code long ago began using 'isfinite' to
detect the issues 'matherr' was designed to address.  For legacy reasons,
we continue to provide an implementation of a 'matherr' callback to ensure
that very old and System V Unix libraries return results detectable by
'isfinite'.  Our Linux code is known to work correctly with and without
it.  That being the case, we just need to make sure that the virtually
unused callback we provide continues to compile and could work if it was
ever called.  We've already addressed that case for other platforms.  Add
Linux to the list.