### PR TITLE
Removing 'github: [metadata]' makes github metadata work again !!! ??

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-github: [metadata]
+### github: [metadata]
 
 plugins:
   - jekyll-include-cache
@@ -28,6 +28,6 @@ footer:
   links:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
-      url: "https://github.com/vision-dbms/vision"
+      url: "GITHUB_PROJECT"
 
 x_suppress_feed: true


### PR DESCRIPTION
Who knew? 🥇 