### PR TITLE
Implement VSingleCoreExecution and VcaEnableBlockingSockets as option…

### DIFF
--- a/software/src/master/src/kernel/V_VThread.h
+++ b/software/src/master/src/kernel/V_VThread.h
@@ -135,6 +135,10 @@ namespace V {
             return m_xState != State_Started;
         }
 
+        int isSingleCoreExecution () const {
+            return m_VSingleCoreExecution;
+        }
+
     /**
      * @name Control
      */
@@ -187,6 +191,11 @@ namespace V {
             return m_pReaper.clearIf (pReaper);
         }
 
+    //  Multi-Core Execution Control
+    public:
+        static int SetSingleCoreExecution ();
+        static void CheckSingleCoreExecution (); 
+
     //  Thread Attachment
     protected:
         /**
@@ -203,6 +212,10 @@ namespace V {
         pthread_t       m_hThread;
         pthread_id_t    m_xThread;
         Reaper::Pointer m_pReaper;
+
+        /** state of all threads **/
+        static int const m_VSingleCoreExecution;
+        static int m_VSingleCoreExecutionChecked;
     };
 }
 

--- a/software/src/master/src/kernel/V_VThread.h
+++ b/software/src/master/src/kernel/V_VThread.h
@@ -214,8 +214,8 @@ namespace V {
         Reaper::Pointer m_pReaper;
 
         /** state of all threads **/
-        static int const m_VSingleCoreExecution;
-        static int m_VSingleCoreExecutionChecked;
+        static bool const m_VSingleCoreExecution;
+        static bool m_VSingleCoreExecutionChecked;
     };
 }
 

--- a/software/src/master/src/kernel/Vca_VDeviceFactory.cpp
+++ b/software/src/master/src/kernel/Vca_VDeviceFactory.cpp
@@ -237,7 +237,7 @@ static char const *const g_pNullDeviceName = "NUL:";
 static char const *const g_pNullDeviceName = "/dev/null";
 
 namespace {
-    int const VcaEnableBlockingSockets = V::GetEnvironmentInteger ("VcaEnableBlockingSockets", 0);
+    bool const VcaEnableBlockingSockets = V::GetEnvironmentBoolean ("VcaEnableBlockingSockets");
 }
 
 #endif
@@ -7218,10 +7218,10 @@ namespace Vca {
 	    SocketDevice (
 		VReferenceable *pContainer, Manager *pManager, Handle &rhSocket
 	    ) : BaseClass (pContainer, pManager, rhSocket) {
-		if (VcaEnableBlockingSockets == 0) makeNonblocking();
+		if (!VcaEnableBlockingSockets) makeNonblocking();
 	    }
 	    SocketDevice (VReferenceable *pContainer, ThisClass &rOther) : BaseClass (pContainer, rOther) {
-		if (VcaEnableBlockingSockets == 0) makeNonblocking();
+		if (!VcaEnableBlockingSockets) makeNonblocking();
 	    }
 
 	//  Destruction

--- a/software/src/master/src/kernel/Vca_VDeviceFactory.cpp
+++ b/software/src/master/src/kernel/Vca_VDeviceFactory.cpp
@@ -236,6 +236,10 @@ static char const *const g_pNullDeviceName = "NUL:";
 
 static char const *const g_pNullDeviceName = "/dev/null";
 
+namespace {
+    int const VcaEnableBlockingSockets = V::GetEnvironmentInteger ("VcaEnableBlockingSockets", 0);
+}
+
 #endif
 
 
@@ -7214,8 +7218,10 @@ namespace Vca {
 	    SocketDevice (
 		VReferenceable *pContainer, Manager *pManager, Handle &rhSocket
 	    ) : BaseClass (pContainer, pManager, rhSocket) {
+		if (VcaEnableBlockingSockets == 0) makeNonblocking();
 	    }
 	    SocketDevice (VReferenceable *pContainer, ThisClass &rOther) : BaseClass (pContainer, rOther) {
+		if (VcaEnableBlockingSockets == 0) makeNonblocking();
 	    }
 
 	//  Destruction


### PR DESCRIPTION
…s to fix github issues #60 and #61.

You have to call sched_setaffinity before the first libV managed thread is spawned.  Because sched_setaffinity modifies a thread specific attribute, not a process specific attribute.  From the docs:

"The affinity mask is actually a per-thread attribute that can be adjusted independently for each of the threads in a thread group. The value returned from a call to gettid(2) can be passed in the argument pid. Specifying pid as 0 will set the attribute for the calling thread, and passing the value returned from a call to getpid(2) will set the attribute for the main thread of the thread group."