### PR TITLE
Simple run state change detection in Vca::Application subclasses

### DIFF
--- a/software/src/master/src/kernel/V_VCommandLine.cpp
+++ b/software/src/master/src/kernel/V_VCommandLine.cpp
@@ -65,8 +65,9 @@ bool V::VCommandLine::Cursor::nextSwitch (char const *pTag, char const *pVariabl
 // -xyz(etc.)
 char const *V::VCommandLine::Cursor::nextTag () {
     while (char const *pWord = nextWord ()) {
-	if ('-' == pWord[0])
-	    return pWord + 1;
+        char const *pTagPart = consumeTag (pWord);
+	if (pWord != pTagPart)
+            return pTagPart;
     }
     return 0;
 }
@@ -74,10 +75,19 @@ char const *V::VCommandLine::Cursor::nextTag () {
 // xyz NOT -xyz(etc.)
 char const *V::VCommandLine::Cursor::nextToken () {
     while (char const *pWord = nextWord ()) {
-	if ('-' != pWord[0])
+        char const *pTagPart = consumeTag (pWord);
+	if (pWord == pTagPart)
 	    return pWord;
     }
     return 0;
+}
+
+char const *V::VCommandLine::Cursor::consumeTag (char const *pWord) {
+    return '-' != pWord[0]
+         ? pWord
+         : '-' != pWord[1]
+         ? pWord + 1
+         : pWord + 2;
 }
 
 

--- a/software/src/master/src/kernel/V_VCommandLine.h
+++ b/software/src/master/src/kernel/V_VCommandLine.h
@@ -110,7 +110,7 @@ namespace V {
 	    void reset () {
 		m_xCommandWord = 0;
 	    }
-	    
+
 	private:
 	    static char const *consumeTag (char const *pWord);
 

--- a/software/src/master/src/kernel/V_VCommandLine.h
+++ b/software/src/master/src/kernel/V_VCommandLine.h
@@ -110,6 +110,9 @@ namespace V {
 	    void reset () {
 		m_xCommandWord = 0;
 	    }
+	    
+	private:
+	    static char const *consumeTag (char const *pWord);
 
 	//  State
 	private:

--- a/software/src/master/src/kernel/Vca_VApplication.h
+++ b/software/src/master/src/kernel/Vca_VApplication.h
@@ -839,6 +839,12 @@ namespace Vca {
         bool setRunStateToStopped ();
 
         /**
+         * Called whenever the run state changes.  Derived class overrides MUST
+         * call the BaseClass version of this routine as the FIRST thing they do.
+         */
+        virtual void onRunStateChange_(RunState xOldState, RunState xNewState);
+
+        /**
          * Handles application startup; must be implemented by concrete subclasses.
          * Stock implementation does nothing, so this application will exit unless this method is overridden.
          *


### PR DESCRIPTION
One of the goals of the _node.js_ external adapter development project is the ability to create Vca based servers and services using _node.js_.  Among other things, such services need to support and conform to the FAAS service lifetime management conventions and APIs intrinsic to Vca.  For example, one very common use case requires the ability to dynamically start an instance of a _node.js_ based service on demand, keep that service alive for the duration of its Vca based consumers, and eventually and quietly shutdown that service when no longer needed.  In short, server-less FAAS, in addition to the other lifetime management policies provided by Vca.

Implementing this requires an effective way to detect run state changes in the **Vca::Application** subclass providing the service.  Surprisingly, while there are a number of ways to do this in the current implementation of Vca, especially for external monitors, there was no direct way to do this for sub-classes of **Vca::VApplication**.  Simple to address by providing an overridable virtual member function at **Vca::Application**, that (plus a pair of benign tag-alongs) is the purpose of this PR.