### PR TITLE
Fix Vxa declaration issue for Solaris/Sparc

### DIFF
--- a/software/src/master/src/kernel/Vxa_VSet.cpp
+++ b/software/src/master/src/kernel/Vxa_VSet.cpp
@@ -57,7 +57,7 @@ Vxa::VSet::~VSet () {
  *************************
  *************************/
 
-V::VString &Vxa::VSet::getDescription_(VString &rResult) const {
+V::VString &Vxa::VSet::getDescription_(V::VString &rResult) const {
     V::VRTTI iRTTI (typeid (*this));
     return rResult << iRTTI.name ();
 }

--- a/software/src/master/src/kernel/Vxa_VType.cpp
+++ b/software/src/master/src/kernel/Vxa_VType.cpp
@@ -58,7 +58,7 @@ Vxa::VType::~VType () {
  *************************
  *************************/
 
-V::VString &Vxa::VType::getDescription_(VString &rResult) const {
+V::VString &Vxa::VType::getDescription_(V::VString &rResult) const {
     V::VRTTI iRTTI (typeid (*this));
     return rResult << iRTTI.name ();
 }


### PR DESCRIPTION
This resolves issue #50 for the Solaris/Sparc build -- 
Please verify that it doesn't break any other builds :^) 
Thanks
